### PR TITLE
Disable screenshot UI widgets when no dbus service

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -62,7 +62,7 @@ public class MainWindow : Hdy.ApplicationWindow {
   };
 
   private bool on_elementary = Gtk.Settings.get_default().gtk_icon_theme_name == "elementary";
-
+  private bool can_do_screenshots = ScreenshotBackend.can_do_screenshots();
   public Editor editor {
     get {
       return( _editor );
@@ -136,10 +136,12 @@ public class MainWindow : Hdy.ApplicationWindow {
   /* Adds keyboard shortcuts for the menu actions */
   private void add_keyboard_shortcuts( Gtk.Application app ) {
     app.set_accels_for_action( "win.action_open",            { "<Control>o" } );
-    app.set_accels_for_action( "win.action_screenshot",      { "<Control>t" } );
-    app.set_accels_for_action( "win.action_screenshot_all",  { "<Control>1" } );
-    app.set_accels_for_action( "win.action_screenshot_win",  { "<Control>2" } );
-    app.set_accels_for_action( "win.action_screenshot_area", { "<Control>3" } );
+    if (can_do_screenshots) {
+      app.set_accels_for_action( "win.action_screenshot",      { "<Control>t" } );
+      app.set_accels_for_action( "win.action_screenshot_all",  { "<Control>1" } );
+      app.set_accels_for_action( "win.action_screenshot_win",  { "<Control>2" } );
+      app.set_accels_for_action( "win.action_screenshot_area", { "<Control>3" } );
+    }
     app.set_accels_for_action( "win.action_save",            { "<Control>s" } );
     app.set_accels_for_action( "win.action_quit",            { "<Control>q" } );
     app.set_accels_for_action( "win.action_undo",            { "<Control>z" } );
@@ -194,12 +196,15 @@ public class MainWindow : Hdy.ApplicationWindow {
     _open_btn.clicked.connect( do_open );
     _header.pack_start( _open_btn );
 
-    _screenshot_btn = new Button.from_icon_name( get_icon_name( "insert-image" ), get_icon_size() );
-    _screenshot_btn.set_tooltip_markup( Utils.tooltip_with_accel( _( "Take Screeshot" ), "<Control>t" ) );
-    _screenshot_btn.clicked.connect(() => {
-      show_screenshot_popover( _screenshot_btn );
-    });
-    _header.pack_start( _screenshot_btn );
+    
+    if (can_do_screenshots) {
+      _screenshot_btn = new Button.from_icon_name( get_icon_name( "insert-image" ), get_icon_size() );
+      _screenshot_btn.set_tooltip_markup( Utils.tooltip_with_accel( _( "Take Screeshot" ), "<Control>t" ) );
+      _screenshot_btn.clicked.connect(() => {
+        show_screenshot_popover( _screenshot_btn );
+      });
+      _header.pack_start( _screenshot_btn );
+    }
 
     /*
     _save_btn = new Button.from_icon_name( get_icon_name( "document-save" ), get_icon_size() );
@@ -347,12 +352,18 @@ public class MainWindow : Hdy.ApplicationWindow {
     var welcome = new Granite.Widgets.Welcome( _( "Welcome to Annotator" ), _( "Let's get started annotating an image" ) );
     welcome.append( "document-open", _( "Open Image From File" ), _( "Open a PNG, JPEG, TIFF or BMP file" ) );
     welcome.append( "edit-paste", _( "Paste Image From Clipboard" ), _( "Open an image from the clipboard" ) );
-    welcome.append( "insert-image", _( "Take A Screenshot" ), _( "Open an image from a screenshot" ) );
+    if (can_do_screenshots) {
+      welcome.append( "insert-image", _( "Take A Screenshot" ), _( "Open an image from a screenshot" ) );
+    }
     welcome.activated.connect((index) => {
       switch( index ) {
         case 0  :  do_open();   break;
         case 1  :  do_paste();  break;
-        case 2  :  show_screenshot_popover( welcome.get_button_from_index( 2 ) );  break;
+        case 2  :  
+          if (can_do_screenshots) {
+            show_screenshot_popover( welcome.get_button_from_index( 2 ) );  
+          }
+          break;
         default :  assert_not_reached();
       }
     });

--- a/src/ScreenshotBackend.vala
+++ b/src/ScreenshotBackend.vala
@@ -47,7 +47,6 @@ public class ScreenshotBackend : Object {
       proxy = Bus.get_proxy_sync<ScreenshotProxy> (BusType.SESSION,
                                                    "org.gnome.Shell.Screenshot",
                                                    "/org/gnome/Shell/Screenshot");
-
       get_capabilities ();
     } catch (Error e) {
       error ("Couldn't get dbus proxy: %s\n", e.message);
@@ -71,6 +70,21 @@ public class ScreenshotBackend : Object {
     if (iface.lookup_method ("ScreenshotAreaWithCursor") != null) {
       can_screenshot_area_with_cursor = true;
     }
+  }
+
+  public static bool can_do_screenshots() {
+    try {
+      var introspectable = Bus.get_proxy_sync<IntrospectableProxy> (
+        BusType.SESSION,
+        "org.gnome.Shell.Screenshot",
+        "/org/gnome/Shell/Screenshot"
+        );
+      var xml = introspectable.introspect ();
+      return true;
+    } catch (Error e) {
+      warning ("Can not take screenshots on this system: %s\n", e.message);
+    }
+    return false;
   }
 
   public async Gdk.Pixbuf? capture (CaptureType type, int delay, bool include_pointer, bool redact) throws Error {

--- a/src/ScreenshotBackend.vala
+++ b/src/ScreenshotBackend.vala
@@ -54,13 +54,7 @@ public class ScreenshotBackend : Object {
   }
 
   private void get_capabilities () throws Error {
-    var introspectable = Bus.get_proxy_sync<IntrospectableProxy> (
-      BusType.SESSION,
-      "org.gnome.Shell.Screenshot",
-      "/org/gnome/Shell/Screenshot"
-      );
-    var xml = introspectable.introspect ();
-
+    var xml = get_instrospectable();
     var node = new DBusNodeInfo.for_xml (xml);
     var iface = node.lookup_interface ("org.gnome.Shell.Screenshot");
     if (iface.lookup_method ("ConcealText") != null) {
@@ -72,14 +66,18 @@ public class ScreenshotBackend : Object {
     }
   }
 
+  private static string get_instrospectable() throws Error {
+    var introspectable = Bus.get_proxy_sync<IntrospectableProxy> (
+      BusType.SESSION,
+      "org.gnome.Shell.Screenshot",
+      "/org/gnome/Shell/Screenshot"
+      );
+    return introspectable.introspect ();
+  }
+
   public static bool can_do_screenshots() {
     try {
-      var introspectable = Bus.get_proxy_sync<IntrospectableProxy> (
-        BusType.SESSION,
-        "org.gnome.Shell.Screenshot",
-        "/org/gnome/Shell/Screenshot"
-        );
-      var xml = introspectable.introspect ();
+      var introspectable = get_instrospectable();
       return true;
     } catch (Error e) {
       warning ("Can not take screenshots on this system: %s\n", e.message);


### PR DESCRIPTION
Not every system that can execute Annotator has
the hardcoded DBus service for screenshots
available. This patch disables the UI controls
for screenshots when the screenshot service is
unavailable on the system to avoid a crash.

Also disables the screenshot keyboard shortcuts.

The cli options have consciously been left to
error out in this context, as the stderr output
should be clear enough.

Signed-off-by: Antoine Mazeas <antoine@karthanis.net>