### PR TITLE
Avoid creating new -@2 icon folders on install

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -5,10 +5,25 @@ foreach i : icon_sizes
         join_paths('images', 'icons', i, meson.project_name() + '.svg'),
         install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'apps')
     )
-    install_data(
-        join_paths('images', 'icons', i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps')
+
+    set_variable(
+        '_system_icon_path',
+        join_paths('/', get_option('prefix'), get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2')
     )
+
+    if run_command(
+        'test', '-d', get_variable('_system_icon_path'),
+        check: false
+    ).returncode() == 0 and run_command(
+        'test', '-L', get_variable('_system_icon_path'),
+        check: false
+    ).returncode() != 0
+        install_symlink(
+            join_paths(meson.project_name() + '.svg'),
+            install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps'),
+            pointing_to: join_paths('..', '..', i + 'x' + i, 'apps', meson.project_name() + '.svg')
+        )
+    endif
 endforeach
 
 i18n.merge_file(


### PR DESCRIPTION
Checks whether the target icon `@2` folder exists on the build system and is not a symlink.  Installs symlink instead of duplicate files.  Closes #74.