### PR TITLE
Added the option for transparent PNG export

### DIFF
--- a/src/Export.vala
+++ b/src/Export.vala
@@ -91,7 +91,7 @@ public class Export {
     var sw  = new Switch();
     sw.halign = Align.END;
     sw.expand = true;
-    sw.activate.connect(() => {
+    sw.notify["active"].connect(() => {
       settings_changed();
     });
 

--- a/src/exports/ExportPNG.vala
+++ b/src/exports/ExportPNG.vala
@@ -37,7 +37,8 @@ public class ExportPNG : Export {
     var fname = repair_filename( filename );
 
     /* Create the drawing surface */
-    var surface = new ImageSurface( Format.RGB24, source.get_width(), source.get_height() );
+    var format = get_bool( "transparency" ) ? Format.ARGB32 : Format.RGB24;
+    var surface = new ImageSurface( format, source.get_width(), source.get_height() );
     var context = new Context( surface );
     canvas.draw_all( context );
 
@@ -62,11 +63,13 @@ public class ExportPNG : Export {
   /* Add the PNG settings */
   public override void add_settings( Grid grid ) {
     add_setting_scale( "compression", grid, _( "Compression" ), null, 0, 9, 1, 5 );
+    add_setting_bool( "transparency", grid, _( "Transparency"), null, false);
   }
 
   /* Save the settings */
   public override void save_settings( Xml.Node* node ) {
     node->set_prop( "compression", get_scale( "compression" ).to_string() );
+    node->set_prop( "transparency", get_bool( "transparency" ).to_string() );
   }
 
   /* Load the settings */
@@ -77,6 +80,10 @@ public class ExportPNG : Export {
       set_scale( "compression", int.parse( c ) );
     }
 
+    var t = node->get_prop( "transparency" );
+    if( t != null ) {
+      set_bool( "transparency", bool.parse( t ) );
+    }
   }
 
 }


### PR DESCRIPTION
The ability to export with transparency (alpha channel) has various use-cases. For example, some screenshot apps such as Gnome Screenshot adds transparent shadows to the windows, omitting any background.

Demo of the UI (Ironically made with Annotator):
![demo](https://github.com/phase1geo/Annotator/assets/1212814/ec284574-bf4f-468d-895b-fda0f3b8cffc)


With this PR, such screenshots (after annotating) go from this:
![non-transparent](https://github.com/phase1geo/Annotator/assets/1212814/1878c820-390e-4d0d-bfdc-49bfd6fb4d8b)

To this:
![transparent](https://github.com/phase1geo/Annotator/assets/1212814/1182d488-2a61-42e8-a422-60e7e474aeb7)

I made the PR such that the default setting is non-transparent (so default behaviour will not break). I also had to fix a bug where the boolean setting didn't autosave, it does now!

What is still TODO after this PR is the translation of the 'transparency' keyword.

This is my first PR for this project, I'm open for any feedback. Have a nice weekend!