### PR TITLE
Add missing icons from elementary/icons (scaled up to 128x128 px)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,8 @@ Afterwards, you can run it via: `flatpak run com.github.phase1geo.annotator`.
   </a>
 </p>
 
+## Credits
+
+Incorporates `document-edit-symbolic.svg` and `image-crop-symbolic.svg` from
+[elementary/icons](https://github.com/elementary/icons/tree/main/actions/symbolic),
+under the terms of the GPL v3.0 license.

--- a/data/com.github.phase1geo.annotator.gresource.xml
+++ b/data/com.github.phase1geo.annotator.gresource.xml
@@ -28,6 +28,8 @@
         <file alias="sequence-symbolic.svg">images/icons/scalable/sequence-symbolic.svg</file>
         <file alias="magnifier-symbolic.svg">images/icons/scalable/magnifier-symbolic.svg</file>
         <file alias="sticker-symbolic.svg">images/icons/scalable/sticker-symbolic.svg</file>
+        <file alias="edit-symbolic.svg">images/icons/scalable/edit-symbolic.svg</file>
+        <file alias="image-crop-symbolic.svg">images/icons/scalable/image-crop-symbolic.svg</file>
 
         <file alias="sticker_data_encryption">images/icons/flat-color-icons/svg/data_encryption.svg</file>
         <file alias="sticker_factory_breakdown">images/icons/flat-color-icons/svg/factory_breakdown.svg</file>

--- a/data/images/icons/scalable/edit-symbolic.svg
+++ b/data/images/icons/scalable/edit-symbolic.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="128"
+   width="128"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="edit-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.53125"
+     inkscape:cx="64"
+     inkscape:cy="64"
+     inkscape:window-width="1600"
+     inkscape:window-height="831"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <g
+     transform="matrix(9.1379618,0,0,9.138288,-4879.5985,91.38288)"
+     id="g4"
+     style="fill:#000000">
+    <path
+       d="m 545.213,-10 a 0.83,0.83 0 0 0 -0.59,0.246 l -0.906,0.912 3.125,3.125 0.91,-0.906 c 0.33,-0.33 0.33,-0.85 0,-1.18 l -1.95,-1.95 A 0.83,0.83 0 0 0 545.213,-10 Z m -2.555,2.22 -8.666,8.668 v 3.119 h 3.121 l 8.665,-8.664 z M 535,1 h 1 v 1 h 1 v 1 h -2 z"
+       fill="#666"
+       id="path2"
+       style="fill:#000000" />
+  </g>
+</svg>

--- a/data/images/icons/scalable/image-crop-symbolic.svg
+++ b/data/images/icons/scalable/image-crop-symbolic.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="128"
+   width="128"
+   version="1.1"
+   id="svg179"
+   sodipodi:docname="image-crop-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs183" />
+  <sodipodi:namedview
+     id="namedview181"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.53125"
+     inkscape:cx="64"
+     inkscape:cy="64"
+     inkscape:window-width="1600"
+     inkscape:window-height="831"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg179" />
+  <g
+     color="#bebebe"
+     transform="matrix(8,0,0,8,-6040,-776)"
+     id="g177"
+     style="fill:#000000">
+    <path
+       d="m 758,97 v 2 h 2 v -2 z m -3,3 v 2 h 11 v 11 h 2 v -13 h -2 z m 3,3 v 7 h 7 v -2 h -5 v -5 z m 11,5 v 2 h 2 v -2 z"
+       fill="#666666"
+       id="path175"
+       style="fill:#000000" />
+  </g>
+</svg>


### PR DESCRIPTION
Closes #77.