### PR TITLE
Hide the Annotator window during portal screenshots.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -719,8 +719,31 @@ public class MainWindow : Gtk.ApplicationWindow {
 
   }
 
+  private async void screenshot_wait_ms( uint ms ) {
+    GLib.Timeout.add( ms, () => {
+      screenshot_wait_ms.callback();
+      return Source.REMOVE;
+    });
+    yield;
+  }
+
   private async void do_screenshot_portal() {
     _welcome.sensitive = false;
+
+    // Hide the Annotator window so it isn't captured.  Honored by the
+    // non-portal path already; mirrored here so the toolbar's screenshot
+    // button (which always uses the portal) behaves the same way.  The
+    // window is shown again from handle_screenshot_callback once the
+    // portal response arrives.
+    var include = Annotator.settings.get_boolean( "screenshot-include-win" );
+    if( !include ) {
+      hide();
+      // Give the compositor time to actually unmap the window before
+      // the portal opens its interactive selector — without this, the
+      // Annotator window is still visible (and capturable) on Wayland.
+      yield screenshot_wait_ms( 200 );
+    }
+
     try {
 
       var bus = Bus.get_sync (BusType.SESSION);
@@ -765,6 +788,9 @@ public class MainWindow : Gtk.ApplicationWindow {
 
     } catch (Error e) {
       warning ("Screenshot failed: %s", e.message);
+      if( !include ) {
+        show();
+      }
     }
 
   }


### PR DESCRIPTION
## Summary

The toolbar's Take Screenshot button always uses the XDG portal path, which previously did not hide the Annotator window before invoking the portal's interactive selector. As a result the window appeared in the captured area on single-monitor setups, forcing users to shrink or move it manually before each screenshot.

The non-portal path already honors the `screenshot-include-win` GSetting via `hide()` / `show()`. This PR mirrors that behavior in `do_screenshot_portal`: when the setting is `false` (the default), hide the window before issuing the portal call and re-show it from the existing response handler (or from the catch block if the D-Bus call itself fails).

On Wayland, `hide()` returns before the compositor has actually unmapped the window, so a 200 ms async wait is inserted between `hide()` and the portal call. Without it the window is still visible (and capturable) when the portal selector appears. The wait is gated on the same `!include` condition so it doesn't affect users who explicitly opt to include the window.

## Test plan

- [x] Click Take Screenshot on Wayland — Annotator window disappears before the portal selector opens.
- [x] Selected region does not contain the Annotator window.
- [x] After confirming the selection, the window reappears with the screenshot loaded.
- [x] Cancelling the portal (Esc) re-shows the window via the existing failure-branch `show()` in `handle_screenshot_callback`.
- [x] Setting `screenshot-include-win` to `true` via `gsettings` keeps the window visible (no regression vs. previous behavior).