### PR TITLE
Subscribe to portal Response signal before issuing the Screenshot call.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -735,23 +735,16 @@ public class MainWindow : Gtk.ApplicationWindow {
                 null
       );
 
-      VariantDict options = new VariantDict( new Variant( "a{sv}" ) );
-      options.insert_value ("interactive", new Variant.boolean (true));
-
-      Variant dict_variant = options.end ();
-      Variant tuple_variant = new Variant ("(s@a{sv})", "interactive", dict_variant);
-
-      Variant result = yield proxy.call(
-        "Screenshot",
-        tuple_variant,
-        DBusCallFlags.NONE,
-        -1,
-        null
-      );
-
-      // Result is (o) → handle path
-      ObjectPath handle;
-      result.get ("(o)", out handle);
+      // Predict the Request handle so we can subscribe to its Response
+      // signal BEFORE issuing the Screenshot call.  Subscribing after
+      // the call returns races against the portal: when the helper is
+      // already running and responds quickly (typical for the second
+      // and subsequent screenshots in a session) the Response can fire
+      // before signal_subscribe is wired up, dropping the screenshot.
+      // The handle path format is defined by the XDG portal spec.
+      var token  = "annotator_%u".printf( Random.next_int() );
+      var sender = bus.get_unique_name().substring( 1 ).replace( ".", "_" );
+      var handle = "/org/freedesktop/portal/desktop/request/%s/%s".printf( sender, token );
 
       bus.signal_subscribe(
         "org.freedesktop.portal.Desktop",
@@ -761,6 +754,21 @@ public class MainWindow : Gtk.ApplicationWindow {
         null,
         DBusSignalFlags.NONE,
         handle_screenshot_callback
+      );
+
+      VariantDict options = new VariantDict( new Variant( "a{sv}" ) );
+      options.insert_value( "interactive",  new Variant.boolean( true ) );
+      options.insert_value( "handle_token", new Variant.string( token ) );
+
+      Variant dict_variant  = options.end ();
+      Variant tuple_variant = new Variant( "(s@a{sv})", "interactive", dict_variant );
+
+      yield proxy.call(
+        "Screenshot",
+        tuple_variant,
+        DBusCallFlags.NONE,
+        -1,
+        null
       );
 
     } catch (Error e) {


### PR DESCRIPTION
## Summary

`do_screenshot_portal` previously called the portal's `Screenshot` method first, read the returned `Request` object path from the reply, and only then subscribed to that path's `Response` signal. When the portal helper is already running and replies quickly, the `Response` signal can fire before `signal_subscribe` is wired up and the screenshot is silently dropped — observed as the very first screenshot of a session sometimes not opening in the canvas while subsequent ones work.

This PR uses the recommended [XDG portal pattern](https://flatpak.github.io/xdg-desktop-portal/docs/request.html) instead:

1. Generate a `handle_token` ourselves.
2. Predict the `Request` object path from it (`/org/freedesktop/portal/desktop/request/<sender>/<token>`, with the sender's unique bus name's leading `:` stripped and `.` replaced by `_`).
3. Subscribe to the `Response` signal **first**.
4. Then issue the `Screenshot` call passing the same `handle_token` in options so the portal uses the predicted handle.

This eliminates the subscribe-after-call race entirely.

## Note on testing

The original symptom is intermittent (depends on portal-helper warm-up timing and scheduler luck), so reproducing it on demand is unreliable. This PR doesn't change the success path — subsequent screenshots in a session work the same as before — and matches the pattern other portal-using applications use.

## Test plan

- [x] Take a screenshot — area selection works, image lands in canvas.
- [x] Take several more in succession — all work.
- [x] Cancel the portal selector (Esc) — Annotator returns to its previous state cleanly.